### PR TITLE
Bump version to v0.2.4 and update dependencies


### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-aurora-serverless",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
-        "aws-cdk-lib": "2.192.0",
-        "cdk-nag": "^2.35.82",
+        "aws-cdk-lib": "2.193.0",
+        "cdk-nag": "^2.35.84",
         "constructs": "^10.4.2",
         "dotenv": "^16.5.0"
       },
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@tsconfig/node22": "^22.0.1",
         "@types/jest": "^29.5.14",
-        "@types/node": "22.15.2",
+        "@types/node": "22.15.3",
         "@types/source-map-support": "^0.5.10",
         "aws-cdk": "2.1012.0",
         "jest": "^29.7.0",
@@ -29,7 +29,7 @@
       },
       "peerDependencies": {
         "aws-cdk": "2.1012.0",
-        "aws-cdk-lib": "2.192.0",
+        "aws-cdk-lib": "2.193.0",
         "constructs": "^10.4.2"
       }
     },
@@ -1133,9 +1133,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.15.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.2.tgz",
-      "integrity": "sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==",
+      "version": "22.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
+      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1299,9 +1299,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.192.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.192.0.tgz",
-      "integrity": "sha512-Y9BAlr9a4QsEsamKc2cOGzX8DpVSOh94wsrMSGRXT0bZaqmixhhmT7WYCrT1KX4MU3gYk3OiwY2BbNyWaNE8Fg==",
+      "version": "2.193.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.193.0.tgz",
+      "integrity": "sha512-Bsf11FM85+s9jSAT8JfDNlrSz6LF3Xa2eSNOyMLcXNopI7eVXP1U6opRHK0waaZGLmQfOwsbSp/9XRMKikkazg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1900,9 +1900,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-nag": {
-      "version": "2.35.82",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.82.tgz",
-      "integrity": "sha512-VKbFivqMYfmjwsnvfMM3ZmE8G/cM6krfqiKAri9iw11bqK2pdkB65UXYkqKBjroLw3sz2zdVbmoFjH2GEflWpg==",
+      "version": "2.35.84",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.84.tgz",
+      "integrity": "sha512-vjgwUHpgcrEoZ7cU7yOJk1tEq6JO5NE81ysi4tg9T+Mj/IvnC9HJTAI5RZidl5uiLe1QnZFBJ1t3YDOfzpfAhg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.156.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-aurora-serverless",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "bin": {
     "aws-aurora-serverless": "bin/aws-aurora-serverless.js"
   },
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@tsconfig/node22": "^22.0.1",
     "@types/jest": "^29.5.14",
-    "@types/node": "22.15.2",
+    "@types/node": "22.15.3",
     "@types/source-map-support": "^0.5.10",
     "aws-cdk": "2.1012.0",
     "jest": "^29.7.0",
@@ -22,14 +22,14 @@
     "typescript": "~5.8.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.192.0",
-    "cdk-nag": "^2.35.82",
+    "aws-cdk-lib": "2.193.0",
+    "cdk-nag": "^2.35.84",
     "constructs": "^10.4.2",
     "dotenv": "^16.5.0"
   },
   "peerDependencies": {
     "aws-cdk": "2.1012.0",
-    "aws-cdk-lib": "2.192.0",
+    "aws-cdk-lib": "2.193.0",
     "constructs": "^10.4.2"
   }
 }


### PR DESCRIPTION
### **PR Type**
Configuration, Dependencies

___

### **PR Description**
- Bump package version from `0.2.3` to `0.2.4`.

- Update dependencies:
  * `aws-cdk-lib` from `2.192.0` to `2.193.0`.
  * `cdk-nag` from `2.35.82` to `2.35.84`.

- Update devDependency `@types/node` from `22.15.2` to `22.15.3`.

- Sync peerDependencies with updated `aws-cdk-lib` version.
